### PR TITLE
Fix crash on invalid colors (Fixes #2)

### DIFF
--- a/functions/fish_logo.fish
+++ b/functions/fish_logo.fish
@@ -14,6 +14,24 @@ function fish_logo \
     set m (set_color $medium_color)
     set i (set_color $inner_color)
 
+    if test (count $o) != 1
+        echo 'Invalid color for "outer_color"' >&2
+        echo 'Usage: fish_logo <outer_color> <medium_color> <inner_color> <mouth> <eye>' >&2
+        return 1
+    end
+
+    if test (count $m) != 1
+        echo 'Invalid color for "medium_color"' >&2
+        echo 'Usage: fish_logo <outer_color> <medium_color> <inner_color> <mouth> <eye>' >&2
+        return 1
+    end
+
+    if test (count $i) != 1
+        echo 'Invalid color for "inner_color"' >&2
+        echo 'Usage: fish_logo <outer_color> <medium_color> <inner_color> <mouth> <eye>' >&2
+        return 1
+    end
+
     echo '                 '$o'___
   ___======____='$m'-'$i'-'$m'-='$o')
 /T            \_'$i'--='$m'=='$o')

--- a/functions/fish_logo.fish
+++ b/functions/fish_logo.fish
@@ -14,21 +14,9 @@ function fish_logo \
     set m (set_color $medium_color)
     set i (set_color $inner_color)
 
-    if test (count $o) != 1
-        echo 'Invalid color for "outer_color"' >&2
-        echo 'Usage: fish_logo <outer_color> <medium_color> <inner_color> <mouth> <eye>' >&2
-        return 1
-    end
-
-    if test (count $m) != 1
-        echo 'Invalid color for "medium_color"' >&2
-        echo 'Usage: fish_logo <outer_color> <medium_color> <inner_color> <mouth> <eye>' >&2
-        return 1
-    end
-
-    if test (count $i) != 1
-        echo 'Invalid color for "inner_color"' >&2
-        echo 'Usage: fish_logo <outer_color> <medium_color> <inner_color> <mouth> <eye>' >&2
+    if test (count $o) != 1; or test (count $m) != 1; or test (count $i) != 1
+        echo 'Invalid color argument'
+        echo $usage
         return 1
     end
 

--- a/functions/fish_logo.fish
+++ b/functions/fish_logo.fish
@@ -9,6 +9,14 @@ function fish_logo \
     [ $mouth ]; or set mouth '['
     [ $eye   ]; or set eye   'O'
 
+    set usage 'Usage: fish_logo <outer_color> <medium_color> <inner_color> <mouth> <eye>
+See set_color --help for more on available colors.'
+
+    if contains -- $outer_color '--help' '-h' '-help'
+        echo $usage
+        return 0
+    end
+
     # shortcuts:
     set o (set_color $outer_color)
     set m (set_color $medium_color)


### PR DESCRIPTION
The crash is caused by fish's [cartesian product operation](https://fishshell.com/docs/current/index.html#cartesian-product), which causes it to try to take the cartesian product of all the lines in the help text as many times as `$o` is printed.  My solution is just to make sure that none of the color results are lists with more than 1 element.